### PR TITLE
resourceMetaportAttachmentDelete fix

### DIFF
--- a/metanetworks/resource_metaport_attachment.go
+++ b/metanetworks/resource_metaport_attachment.go
@@ -109,7 +109,7 @@ func resourceMetaportAttachmentDelete(d *schema.ResourceData, m interface{}) err
 	// Note that if the entry has already been deleted this won't fail.
 	for i := 0; i < len(metaport.MappedElements); i++ {
 		if metaport.MappedElements[i] == elementID {
-			metaport.MappedElements = append(metaport.MappedElements[i:], metaport.MappedElements[i+1:]...)
+			metaport.MappedElements = append(metaport.MappedElements[:i], metaport.MappedElements[i+1:]...)
 			break
 		}
 	}


### PR DESCRIPTION
There was an issue while deleting MetaPortAttachment.
Instead of deleting a specific element (based on the pointer) - all elements before the pointer were removed.
This change should fix bug reported in: https://github.com/mataneine/terraform-provider-metanetworks/issues/8
