### PR TITLE
Fix resourceRoutingGroupAttachmentDelete

### DIFF
--- a/metanetworks/resource_routing_group_attachment.go
+++ b/metanetworks/resource_routing_group_attachment.go
@@ -110,7 +110,7 @@ func resourceRoutingGroupAttachmentDelete(d *schema.ResourceData, m interface{})
 	// Note that if the entry has already been deleted this won't fail.
 	for i := 0; i < len(routingGroup.MappedElements); i++ {
 		if routingGroup.MappedElements[i] == elementID {
-			routingGroup.MappedElements = append(routingGroup.MappedElements[i:], routingGroup.MappedElements[i+1:]...)
+			routingGroup.MappedElements = append(routingGroup.MappedElements[:i], routingGroup.MappedElements[i+1:]...)
 			break
 		}
 	}


### PR DESCRIPTION
There was an issue while deleting RoutingGroupAttachment.
Instead of deleting a specific element (based on the pointer) - all elements before the pointer were removed.
Basically the same patter as in https://github.com/mataneine/terraform-provider-metanetworks/pull/12