### PR TITLE
#36 enhancement fix

### DIFF
--- a/metanetworks/network_element.go
+++ b/metanetworks/network_element.go
@@ -23,7 +23,7 @@ type NetworkElement struct {
 	ExpiresAt     string         `json:"expires_at,omitempty" meta_api:"read_only"`
 	ID            string         `json:"id,omitempty" meta_api:"read_only"`
 	MappedService string         `json:"mapped_service,omitempty"`
-	MappedSubnets []string       `json:"mapped_subnets,omitempty"`
+	MappedSubnets []string       `json:"mapped_subnets"`
 	ModifiedAt    string         `json:"modified_at,omitempty" meta_api:"read_only"`
 	Name          string         `json:"name"`
 	NetID         int64          `json:"net_id,omitempty" meta_api:"read_only"`


### PR DESCRIPTION
now allows for [] as mapped_subnets without omitting it, and creates empty mapped_subnets resource in meta as expected.