### PR TITLE
disable pagination for user and group API endpoints

### DIFF
--- a/metanetworks/config.go
+++ b/metanetworks/config.go
@@ -18,6 +18,7 @@ const (
 	maxIdleConnections int    = 10
 	requestTimeout     int    = 60
 	configPath         string = ".metanetworks/credentials.json"
+	disable_pagination string = "pagination=false&"
 )
 
 // Config ...

--- a/metanetworks/group.go
+++ b/metanetworks/group.go
@@ -48,7 +48,7 @@ func groupToResource(d *schema.ResourceData, m *Group) error {
 // GetGroups ...
 func (c *Client) GetGroups(name string) ([]Group, error) {
 	var groups []Group
-	err := c.Read(groupsEndpoint+"?expand=true&name="+url.QueryEscape(name), &groups)
+	err := c.Read(groupsEndpoint+"?"+disable_pagination+"expand=true&name="+url.QueryEscape(name), &groups)
 
 	if err != nil {
 		return nil, err

--- a/metanetworks/user.go
+++ b/metanetworks/user.go
@@ -61,7 +61,7 @@ func userToResource(d *schema.ResourceData, m *User) error {
 // GetUsers ...
 func (c *Client) GetUsers(email string) ([]User, error) {
 	var users []User
-	err := c.Read(usersEndpoint+"?expand=true&email="+url.QueryEscape(email), &users)
+	err := c.Read(usersEndpoint+"?"+disable_pagination+"expand=true&email="+url.QueryEscape(email), &users)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As stated in https://help.metanetworks.com/knowledgebase/meta_api_pagination/

MetaNetworks is going to implement pagination on some endpoints. 

Here is some info from Meta:
**What is being changed? Why Pagination?**
Some of the API endpoints may return an excessive list of elements, making it difficult to handle and process.
To overcome this, we are introducing pagination for a few of the existing API endpoints:
GET /orgs
GET /groups
GET /users
GET /metaconnects
GET /network_elements